### PR TITLE
Updates alias command to allow for name to be overridden by alias_nam…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Here is a list of the current supported config keys and values along with their 
 * `config_path` (default: `$HOME/.hermes/`) - the directory where hermes will store configuration files such as its internal cache and the hermes target file. **NOTE:** you will want to set this in your hermes configuration file **BEFORE** you run `hermes setup` since that command will create the config folder. 
 * `target_file` (default: `.hermes_target`) -  after running the hermes command, if there is a valid target (e.g. repo that you have cloned or want to jump to), hermes writes out the full path into the hermes target file. From there, the alias in your shell profile will read this, jump to the directory and then remove the target file. **NOTE:** `target_file` only specifies the file name, the file will be created in the `config_path`. if you change the target file after setting the hermes alias, you would need to open a new terminal session or re-source your profile file for the alias to realize the change
 * `cache_file` (default: `cache.json`) - hermes stores a cache of repos it is aware of to allow for tab completion and prompts. this will be in json format. **NOTE:** `cache_file` only specifies the file name, the file will be created in the `config_path`
+* `alias_name` (default: `hermes`) - the name of the alias function which calls through to the hermes binary. this will be the command you run when using hermes.
 
 <a name="example-config"></a>
 ### Example .hermes.yml File
@@ -65,6 +66,7 @@ repo_path: /Users/jeremychambers/test-repos/
 config_path: /Users/jeremychambers/.hermes-config/
 cache_file: cached-repos.json
 target_file: .hermes_target_file
+alias_name: hit
 ```
 
 ## Usage

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -30,6 +30,7 @@ var aliasCmd = &cobra.Command{
 type AliasData struct {
 	ConfigDir      string
 	TargetFileName string
+	AliasName      string
 }
 
 func generateAlias() (string, error) {
@@ -37,15 +38,18 @@ func generateAlias() (string, error) {
 	data := AliasData{
 		ConfigDir:      viper.GetString("config_path"),
 		TargetFileName: viper.GetString("target_file"),
+		AliasName:      viper.GetString("alias_name"),
 	}
 
 	aliasTemplate := `
-function hermes() {
-	export HERMES_BIN="$(which hermes)"
+function {{ .AliasName }}() {
+	local HERMES_BIN="$(which hermes)"
 	$HERMES_BIN $@
+	local EXIT_STATUS=$?
 	if [ -f {{ .ConfigDir }}{{ .TargetFileName }} ]; then
 		cd $(cat {{ .ConfigDir }}{{ .TargetFileName }}) && rm {{ .ConfigDir }}{{ .TargetFileName }}
 	fi
+	return $EXIT_STATUS
 }
 	
 `

--- a/cmd/alias_test.go
+++ b/cmd/alias_test.go
@@ -20,10 +20,24 @@ func init() {
 	viper.Set("target_file", testTargetFile)
 }
 
-func TestGenerateAlias(t *testing.T) {
+func TestGenerateAliasDefault(t *testing.T) {
 	assert := assert.New(t)
 
 	alias, err := generateAlias()
 	assert.Nil(err, "generateAlias should not return an error")
+	assert.Contains(alias, fmt.Sprintf("function %s()", "hermes"))
+	assert.Contains(alias, `$HERMES_BIN $@
+	local EXIT_STATUS=$?`, "alias should capture the exit code from the hermes binaray")
+	assert.Contains(alias, "return $EXIT_STATUS", "alias should return exit status from binary")
 	assert.Contains(alias, fmt.Sprintf("%s%s", testConfigPath, testTargetFile), "generateAlias should have the correct target path")
+}
+
+func TestGenerateAliasWithName(t *testing.T) {
+	assert := assert.New(t)
+
+	testAliasName := "testAlias"
+	viper.Set("alias_name", testAliasName)
+	alias, err := generateAlias()
+	assert.Nil(err, "generateAlias should not return an error")
+	assert.Contains(alias, fmt.Sprintf("function %s()", testAliasName))
 }

--- a/cmd/exit_status.go
+++ b/cmd/exit_status.go
@@ -1,0 +1,9 @@
+package cmd
+
+const (
+	// ExitCannotExecute status for cannot execute
+	ExitCannotExecute = 126
+
+	// ExitInvalidArguments status for invalid arguments
+	ExitInvalidArguments = 128
+)


### PR DESCRIPTION
…e config, Removes unused viper config remotes_file, Updates root.go to set default alias_name to hermes, Fixes alias to correctly return exit code from hermes binary, Adds exit code constants, Fixes bug where incorrect repo name will still attempt to clone