### PR TITLE
Move credentialStorer.Close() call to remote.go where it is use, Upda…

### DIFF
--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -53,6 +53,8 @@ var remoteAddCmd = &cobra.Command{
 }
 
 func remoteAddHandler(cmd *cobra.Command, args []string) {
+	defer credentialsStorer.Close()
+
 	remoteURL, err := url.Parse(args[0])
 	remoteName := remoteURL.Hostname()
 	if err != nil {

--- a/cmd/remote_test.go
+++ b/cmd/remote_test.go
@@ -108,6 +108,12 @@ func (suite *RemoteCmdSuite) TestWithTokenAuth() {
 		Return(credentials.Credential{}, credentials.ErrCredentialNotFound).
 		Times(1)
 
+	suite.mockCredentialStorer.
+		EXPECT().
+		Close().
+		Return(nil).
+		Times(1)
+
 	gomock.InOrder(
 		// prompt for token
 		mockPrompter.
@@ -279,6 +285,12 @@ func (suite *RemoteCmdSuite) TestWithStoredTokenAuth() {
 			Type:  "token",
 			Token: "1234abcd",
 		}, nil).
+		Times(1)
+
+	suite.mockCredentialStorer.
+		EXPECT().
+		Close().
+		Return(nil).
 		Times(1)
 
 	mockPrompter.
@@ -478,6 +490,12 @@ func (suite *RemoteCmdSuite) TestRemoteAddWithAll() {
 			AddRemote("https://github.com", "github.com", "https").
 			Return(nil).
 			Times(1),
+
+		suite.mockCredentialStorer.
+			EXPECT().
+			Close().
+			Return(nil).
+			Times(1),
 	)
 
 	gomock.InOrder(
@@ -596,6 +614,12 @@ func (suite *RemoteCmdSuite) TestRemoteAddSSH() {
 		EXPECT().
 		Get("github.com").
 		Return(credentials.Credential{}, credentials.ErrCredentialNotFound).
+		Times(1)
+
+	suite.mockCredentialStorer.
+		EXPECT().
+		Close().
+		Return(nil).
 		Times(1)
 
 	gomock.InOrder(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -175,16 +175,10 @@ func getHandler(cmd *cobra.Command, args []string) {
 
 // Execute runs the root command
 func Execute() {
-	defer cleanup()
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		cleanup()
 		os.Exit(ExitCannotExecute)
 	}
-}
-
-func cleanup() {
-	credentialsStorer.Close()
 }
 
 func init() {


### PR DESCRIPTION
…te tests to expect call to Close